### PR TITLE
Improve Code Coverage and Fix Bugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
 
 ## RobotlegsJS-SignalCommandMap 0.1.0
 
-### v0.1.0
+### [v0.1.0](https://github.com/RobotlegsJS/RobotlegsJS-SignalCommandMap/releases/tag/0.1.0) - 2017-11-16
 
 - Update @robotlegsjs/signals to version 0.0.12 (see #26).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@
 
 - Add Pull Request Template (see #30).
 
+- Improve Code Coverage and Fix Bugs (see #31).
+
 - Update dev dependencies to latest version.
 
 ## RobotlegsJS-SignalCommandMap 0.0.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 
   - [ ] Find a way to keep a new line between **@inject** anotation and property declarations.
 
-- [ ] Improve Code Coverage to reach 100%.
+- [x] Improve Code Coverage to reach 100%.
 
 ## RobotlegsJS-SignalCommandMap 0.1.0
 

--- a/src/robotlegs/bender/extensions/signalCommandMap/api/ISignalCommandMap.ts
+++ b/src/robotlegs/bender/extensions/signalCommandMap/api/ISignalCommandMap.ts
@@ -5,7 +5,9 @@
 //  in accordance with the terms of the license agreement accompanying it.
 // ------------------------------------------------------------------------------
 
-import { ICommandMapper, ICommandUnmapper } from "@robotlegsjs/core";
+import { IClass, ICommandMapper, ICommandUnmapper } from "@robotlegsjs/core";
+
+import { ISignal } from "@robotlegsjs/signals";
 
 /**
  * The Signal Command Map allows you to bind Signals to Commands
@@ -17,14 +19,14 @@ export interface ISignalCommandMap {
      * @param signalClass The concrete Signal class
      * @return Command mapper
      */
-    map(signalClass: Object): ICommandMapper;
+    map(signalClass: IClass<ISignal>): ICommandMapper;
 
     /**
      * Unmaps a Signal based trigger from a command
      * @param signalClass The concrete Signal class
      * @return Command unmapper
      */
-    unmap(signalClass: Object): ICommandUnmapper;
+    unmap(signalClass: IClass<ISignal>): ICommandUnmapper;
 
     /**
      * Adds a handler to process mappings

--- a/src/robotlegs/bender/extensions/signalCommandMap/impl/SignalCommandMap.ts
+++ b/src/robotlegs/bender/extensions/signalCommandMap/impl/SignalCommandMap.ts
@@ -8,6 +8,7 @@
 import {
     injectable,
     inject,
+    IClass,
     IInjector,
     IContext,
     ILogger,
@@ -16,6 +17,8 @@ import {
     ICommandUnmapper,
     CommandTriggerMap
 } from "@robotlegsjs/core";
+
+import { ISignal } from "@robotlegsjs/signals";
 
 import { ISignalCommandMap } from "../api/ISignalCommandMap";
 import { SignalCommandTrigger } from "./SignalCommandTrigger";
@@ -60,14 +63,14 @@ export class SignalCommandMap implements ISignalCommandMap {
     /**
      * @inheritDoc
      */
-    public map(signalClass: Object): ICommandMapper {
+    public map(signalClass: IClass<ISignal>): ICommandMapper {
         return this.getTrigger(signalClass).createMapper();
     }
 
     /**
      * @inheritDoc
      */
-    public unmap(signalClass: Object): ICommandUnmapper {
+    public unmap(signalClass: IClass<ISignal>): ICommandUnmapper {
         return this.getTrigger(signalClass).createMapper();
     }
 
@@ -83,7 +86,7 @@ export class SignalCommandMap implements ISignalCommandMap {
     /* Private Functions                                                          */
     /*============================================================================*/
 
-    private createTrigger(signalClass: Object): ICommandTrigger {
+    private createTrigger(signalClass: IClass<ISignal>): ICommandTrigger {
         return new SignalCommandTrigger(
             this._injector,
             signalClass,
@@ -91,11 +94,11 @@ export class SignalCommandMap implements ISignalCommandMap {
         );
     }
 
-    private getTrigger(signalClass: Object): SignalCommandTrigger {
+    private getTrigger(signalClass: IClass<ISignal>): SignalCommandTrigger {
         return <SignalCommandTrigger>this._triggerMap.getTrigger(signalClass);
     }
 
-    private getKey(signalClass: Object): Object {
+    private getKey(signalClass: IClass<ISignal>): IClass<ISignal> {
         return signalClass;
     }
 }

--- a/src/robotlegs/bender/extensions/signalCommandMap/impl/SignalCommandTrigger.ts
+++ b/src/robotlegs/bender/extensions/signalCommandMap/impl/SignalCommandTrigger.ts
@@ -58,7 +58,7 @@ export class SignalCommandTrigger implements ICommandTrigger {
         );
         this._executor = new CommandExecutor(
             injector,
-            this._mappings.removeMapping
+            this._mappings.removeMapping.bind(this._mappings)
         );
     }
 

--- a/src/robotlegs/bender/extensions/signalCommandMap/impl/SignalCommandTrigger.ts
+++ b/src/robotlegs/bender/extensions/signalCommandMap/impl/SignalCommandTrigger.ts
@@ -6,6 +6,7 @@
 // ------------------------------------------------------------------------------
 
 import {
+    IClass,
     IInjector,
     ILogger,
     ICommandExecutor,
@@ -26,7 +27,7 @@ export class SignalCommandTrigger implements ICommandTrigger {
     /* Private Properties                                                         */
     /*============================================================================*/
 
-    private _signalClass: any;
+    private _signalClass: IClass<ISignal>;
 
     private _signal: ISignal;
 
@@ -45,7 +46,7 @@ export class SignalCommandTrigger implements ICommandTrigger {
      */
     constructor(
         injector: IInjector,
-        signalClass: any,
+        signalClass: IClass<ISignal>,
         processors?: Function[],
         logger?: ILogger
     ) {

--- a/src/robotlegs/bender/extensions/signalCommandMap/impl/SignalCommandTrigger.ts
+++ b/src/robotlegs/bender/extensions/signalCommandMap/impl/SignalCommandTrigger.ts
@@ -82,7 +82,6 @@ export class SignalCommandTrigger implements ICommandTrigger {
                 .bind(this._signalClass)
                 .to(this._signalClass)
                 .inSingletonScope();
-            // this._injector.map(this._signalClass).asSingleton();
         }
         this._signal = this._injector.get<ISignal>(this._signalClass);
         this._signal.add(this.routePayloadToCommands);

--- a/src/robotlegs/bender/extensions/signalCommandMap/impl/SignalCommandTrigger.ts
+++ b/src/robotlegs/bender/extensions/signalCommandMap/impl/SignalCommandTrigger.ts
@@ -105,11 +105,18 @@ export class SignalCommandTrigger implements ICommandTrigger {
     /* Private Functions                                                          */
     /*============================================================================*/
 
-    private routePayloadToCommands = (...valueObjects): void => {
+    private routePayloadToCommands = (...valueObjects: any[]): void => {
+        let valueClasses: any[] = this._signal.valueClasses;
+
+        if (this._signal.valueClasses.length < valueObjects.length) {
+            valueClasses = valueObjects.map(obj => obj.constructor);
+        }
+
         let payload: CommandPayload = new CommandPayload(
             valueObjects,
-            this._signal.valueClasses
+            valueClasses
         );
+
         this._executor.executeCommands(this._mappings.getList(), payload);
     };
 }

--- a/src/robotlegs/bender/extensions/signalCommandMap/impl/SignalCommandTrigger.ts
+++ b/src/robotlegs/bender/extensions/signalCommandMap/impl/SignalCommandTrigger.ts
@@ -107,10 +107,6 @@ export class SignalCommandTrigger implements ICommandTrigger {
     private routePayloadToCommands = (...valueObjects: any[]): void => {
         let valueClasses: any[] = this._signal.valueClasses;
 
-        if (this._signal.valueClasses.length < valueObjects.length) {
-            valueClasses = valueObjects.map(obj => obj.constructor);
-        }
-
         let payload: CommandPayload = new CommandPayload(
             valueObjects,
             valueClasses

--- a/src/robotlegs/bender/extensions/signalCommandMap/impl/SignalCommandTrigger.ts
+++ b/src/robotlegs/bender/extensions/signalCommandMap/impl/SignalCommandTrigger.ts
@@ -51,7 +51,11 @@ export class SignalCommandTrigger implements ICommandTrigger {
     ) {
         this._injector = injector;
         this._signalClass = signalClass;
-        this._mappings = new CommandMappingList(this, processors, logger);
+        this._mappings = new CommandMappingList(
+            this,
+            processors ? processors : [],
+            logger
+        );
         this._executor = new CommandExecutor(
             injector,
             this._mappings.removeMapping

--- a/test/robotlegs/bender/extensions/signalCommandMap/impl/signalCommandMap.test.ts
+++ b/test/robotlegs/bender/extensions/signalCommandMap/impl/signalCommandMap.test.ts
@@ -1,0 +1,120 @@
+// ------------------------------------------------------------------------------
+//  Copyright (c) 2017 RobotlegsJS. All Rights Reserved.
+//
+//  NOTICE: You are permitted to use, modify, and distribute this file
+//  in accordance with the terms of the license agreement accompanying it.
+// ------------------------------------------------------------------------------
+
+import "../../../../../entry.ts";
+
+import sinon = require("sinon");
+
+import { assert } from "chai";
+
+import {
+    ISignal,
+    MonoSignal,
+    OnceSignal,
+    Signal,
+    DeluxeSignal,
+    PrioritySignal
+} from "@robotlegsjs/signals";
+
+import {
+    injectable,
+    IContext,
+    IInjector,
+    ICommandMapper,
+    ICommandUnmapper,
+    Context,
+    CommandMapper
+} from "@robotlegsjs/core";
+
+import { SignalCommandMap } from "../../../../../../src/robotlegs/bender/extensions/signalCommandMap/impl/SignalCommandMap";
+
+import { NullCommand } from "../support/NullCommand";
+
+describe("SignalCommandMap", () => {
+    let signal: ISignal;
+    let context: IContext;
+    let injector: IInjector;
+    let subject: SignalCommandMap;
+
+    beforeEach(() => {
+        signal = new Signal();
+        context = new Context();
+        injector = context.injector;
+        subject = new SignalCommandMap(context);
+    });
+
+    afterEach(() => {
+        signal.removeAll();
+        if (context.initialized) {
+            context.destroy();
+        }
+        signal = null;
+        context = null;
+        injector = null;
+        subject = null;
+    });
+
+    it("map_creates_mapper", () => {
+        let mapper: any = subject.map(Signal);
+
+        assert.instanceOf(mapper, CommandMapper);
+    });
+
+    it("test_map_returns_new_mapper_when_identical_signal", () => {
+        let mapper1: ICommandMapper = subject.map(Signal);
+        let mapper2: ICommandMapper = subject.map(Signal);
+
+        assert.isNotNull(mapper1);
+        assert.isNotNull(mapper2);
+        assert.notEqual(mapper1, mapper2);
+    });
+
+    it("test_unmap_returns_unmapper", () => {
+        let mapper: any = subject.unmap(Signal);
+
+        assert.instanceOf(mapper, CommandMapper);
+    });
+
+    it("test_robust_unmapping_non_existent_mappings", () => {
+        subject.unmap(Signal).fromCommand(NullCommand);
+    });
+
+    it("mapping_processor_is_called", () => {
+        let callCount: number = 0;
+        subject.addMappingProcessor((mapping: any) => {
+            callCount++;
+        });
+        subject.map(Signal).toCommand(NullCommand);
+        assert.equal(callCount, 1);
+    });
+
+    it("mapping_processors_are_called", () => {
+        let callCount: number = 0;
+        subject.addMappingProcessor((mapping: any) => {
+            callCount++;
+        });
+        subject.addMappingProcessor((mapping: any) => {
+            callCount++;
+        });
+        subject.addMappingProcessor((mapping: any) => {
+            callCount++;
+        });
+        subject.map(Signal).toCommand(NullCommand);
+        assert.equal(callCount, 3);
+    });
+
+    it("mapping_processor_added_twice_is_called_once", () => {
+        let callCount: number = 0;
+        let handler: Function = (mapping: any) => {
+            callCount++;
+        };
+        subject.addMappingProcessor(handler);
+        subject.addMappingProcessor(handler);
+        subject.map(Signal).toCommand(NullCommand);
+        assert.equal(callCount, 1);
+    });
+});

--- a/test/robotlegs/bender/extensions/signalCommandMap/impl/signalCommandMapIntegration.test.ts
+++ b/test/robotlegs/bender/extensions/signalCommandMap/impl/signalCommandMapIntegration.test.ts
@@ -1,0 +1,597 @@
+// ------------------------------------------------------------------------------
+//  Copyright (c) 2017 RobotlegsJS. All Rights Reserved.
+//
+//  NOTICE: You are permitted to use, modify, and distribute this file
+//  in accordance with the terms of the license agreement accompanying it.
+// ------------------------------------------------------------------------------
+
+import "../../../../../entry.ts";
+
+import sinon = require("sinon");
+
+import { assert } from "chai";
+
+import {
+    ISignal,
+    MonoSignal,
+    OnceSignal,
+    Signal,
+    DeluxeSignal,
+    PrioritySignal
+} from "@robotlegsjs/signals";
+
+import {
+    injectable,
+    IContext,
+    IInjector,
+    ICommandMapper,
+    ICommandUnmapper,
+    Context,
+    CommandMapper
+} from "@robotlegsjs/core";
+
+import { ISignalCommandMap } from "../../../../../../src/robotlegs/bender/extensions/signalCommandMap/api/ISignalCommandMap";
+import { SignalCommandMap } from "../../../../../../src/robotlegs/bender/extensions/signalCommandMap/impl/SignalCommandMap";
+
+import { CascadingCommand } from "../support/CascadingCommand";
+import { ExecuteMethodWithParametersCommand } from "../support/ExecuteMethodWithParametersCommand";
+import { GrumpyGuard } from "../support/GrumpyGuard";
+import { HappyGuard } from "../support/HappyGuard";
+import { NullCommand } from "../support/NullCommand";
+import { Payload } from "../support/Payload";
+import { PayloadInjectedCallbackCommand } from "../support/PayloadInjectedCallbackCommand";
+import { PayloadInjectedGuard } from "../support/PayloadInjectedGuard";
+import { PayloadInjectedHook } from "../support/PayloadInjectedHook";
+import { ReportingCommand } from "../support/ReportingCommand";
+import { ReportingCommand2 } from "../support/ReportingCommand2";
+import { ReportingCommand3 } from "../support/ReportingCommand3";
+import { ReportingGuard } from "../support/ReportingGuard";
+import { ReportingGuard2 } from "../support/ReportingGuard2";
+import { ReportingHook } from "../support/ReportingHook";
+import { StrictPayloadCarryingSignal } from "../support/StrictPayloadCarryingSignal";
+import { SupportSignal } from "../support/SupportSignal";
+import { SupportSignal2 } from "../support/SupportSignal2";
+
+describe("SignalCommandMap", () => {
+    let context: IContext;
+    let injector: IInjector;
+    let signalCommandMap: SignalCommandMap;
+    let reportedExecutions: any[];
+
+    function reportingFunction(item: any, itemClass: any): void {
+        reportedExecutions.push(itemClass);
+    }
+
+    function commandExecutionCount(
+        totalEvents: number = 1,
+        oneshot: boolean = false,
+        ...valueObjects
+    ): number {
+        let executeCount: number = 0;
+
+        injector
+            .bind("Function")
+            .toFunction((item: any, itemClass: any) => {
+                executeCount++;
+            })
+            .whenTargetNamed("executeCallback");
+
+        signalCommandMap
+            .map(SupportSignal)
+            .toCommand(ReportingCommand)
+            .once(oneshot);
+
+        let signal: SupportSignal = injector.get<SupportSignal>(SupportSignal);
+
+        while (totalEvents--) {
+            signal.dispatch.apply(signal, valueObjects);
+        }
+
+        return executeCount;
+    }
+
+    function oneshotCommandExecutionCount(totalEvents: number = 1): number {
+        return commandExecutionCount(totalEvents, true);
+    }
+
+    function hookCallCount(...hooks): number {
+        let callCount: number = 0;
+
+        injector
+            .bind("Function")
+            .toFunction((item: any, itemClass: any) => {
+                // do nothing
+            })
+            .whenTargetNamed("executeCallback");
+
+        injector
+            .bind("Function")
+            .toFunction((item: any, itemClass: any) => {
+                callCount++;
+            })
+            .whenTargetNamed("hookCallback");
+
+        signalCommandMap
+            .map(SupportSignal)
+            .toCommand(ReportingCommand)
+            .withHooks(hooks);
+        let signal: SupportSignal = injector.get(SupportSignal);
+        signal.dispatch();
+        return callCount;
+    }
+
+    function commandExecutionCountWithGuards(...guards): number {
+        let executionCount: number = 0;
+
+        injector
+            .bind("Function")
+            .toFunction((item: any, itemClass: any) => {
+                executionCount++;
+            })
+            .whenTargetNamed("executeCallback");
+
+        signalCommandMap
+            .map(SupportSignal)
+            .toCommand(ReportingCommand)
+            .withGuards(guards);
+
+        let signal: SupportSignal = injector.get(SupportSignal);
+
+        signal.dispatch();
+
+        return executionCount;
+    }
+
+    beforeEach(() => {
+        context = new Context();
+        injector = context.injector;
+        signalCommandMap = new SignalCommandMap(context);
+        reportedExecutions = [];
+        injector
+            .bind("Function")
+            .toFunction(reportingFunction)
+            .whenTargetNamed("reportingFunction");
+    });
+
+    afterEach(() => {
+        if (context.initialized) {
+            context.destroy();
+        }
+        context = null;
+        injector = null;
+        signalCommandMap = null;
+    });
+
+    it("test_command_executes_successfully", () => {
+        assert.equal(commandExecutionCount(1), 1);
+    });
+
+    it("test_command_executes_repeatedly", () => {
+        assert.equal(commandExecutionCount(5), 5);
+    });
+
+    it("test_fireOnce_command_executes_once", () => {
+        assert.equal(oneshotCommandExecutionCount(5), 1);
+    });
+
+    it("test_payload_is_injected_into_command", () => {
+        let injected: any = null;
+
+        injector
+            .bind("Function")
+            .toFunction((command: PayloadInjectedCallbackCommand) => {
+                injected = command.payload;
+            })
+            .whenTargetNamed("executeCallback");
+        signalCommandMap
+            .map(StrictPayloadCarryingSignal)
+            .toCommand(PayloadInjectedCallbackCommand);
+        let payload: Payload = new Payload();
+        let signal: StrictPayloadCarryingSignal = injector.get(
+            StrictPayloadCarryingSignal
+        );
+
+        signal.dispatch(payload);
+
+        assert.equal(injected, payload);
+    });
+
+    it("test_only_commands_mapped_to_dispatching_signal_are_executed", () => {
+        injector
+            .bind("Function")
+            .toFunction(reportingFunction)
+            .whenTargetNamed("executeCallback");
+
+        signalCommandMap.map(SupportSignal).toCommand(ReportingCommand);
+
+        signalCommandMap.map(SupportSignal2).toCommand(ReportingCommand2);
+
+        const expected: any[] = [ReportingCommand2];
+        let signal: SupportSignal2 = injector.get(SupportSignal2);
+
+        signal.dispatch();
+
+        assert.deepEqual(reportedExecutions, expected);
+    });
+
+    it("test_command_does_not_execute_after_signal_unmapped", () => {
+        let executeCount: number = 0;
+
+        injector
+            .bind("Function")
+            .toFunction((item: any, itemClass: any) => {
+                executeCount++;
+            })
+            .whenTargetNamed("executeCallback");
+
+        signalCommandMap.map(SupportSignal).toCommand(ReportingCommand);
+        signalCommandMap.unmap(SupportSignal).fromCommand(ReportingCommand);
+
+        let signal: SupportSignal = injector.get(SupportSignal);
+
+        signal.dispatch();
+
+        assert.equal(executeCount, 0);
+    });
+
+    it("test_oneshot_mappings_should_not_bork_stacked_mappings", () => {
+        injector
+            .bind("Function")
+            .toFunction(reportingFunction)
+            .whenTargetNamed("executeCallback");
+
+        signalCommandMap.map(SupportSignal).toCommand(ReportingCommand);
+        signalCommandMap.map(SupportSignal).toCommand(ReportingCommand2);
+
+        let signal: SupportSignal = injector.get(SupportSignal);
+
+        signal.dispatch();
+
+        assert.deepEqual(reportedExecutions, [
+            ReportingCommand,
+            ReportingCommand2
+        ]);
+    });
+
+    it("test_one_shot_command_should_not_cause_infinite_loop_when_dispatching_to_self", () => {
+        let executeCount: number = 0;
+
+        injector
+            .bind(SupportSignal)
+            .toSelf()
+            .inSingletonScope();
+
+        let signal: SupportSignal = injector.get(SupportSignal);
+
+        injector
+            .bind("Function")
+            .toFunction((item: any, itemClass: any) => {
+                executeCount++;
+                signal.dispatch();
+            })
+            .whenTargetNamed("executeCallback");
+
+        signalCommandMap
+            .map(SupportSignal)
+            .toCommand(ReportingCommand)
+            .once();
+
+        signal.dispatch();
+
+        assert.equal(executeCount, 1);
+    });
+
+    it("test_cascaded_dispatches_should_not_bork_mappings", () => {
+        injector
+            .bind("Function")
+            .toFunction((item: any, itemClass: any) => {
+                reportingFunction(item, itemClass);
+
+                injector.unbind("Function");
+                injector
+                    .bind("Function")
+                    .toFunction(reportingFunction)
+                    .whenTargetNamed("executeCallback");
+
+                let signal2: SupportSignal2 = injector.get(SupportSignal2);
+                signal2.dispatch();
+            })
+            .whenTargetNamed("executeCallback");
+
+        signalCommandMap.map(SupportSignal).toCommand(ReportingCommand);
+        signalCommandMap.map(SupportSignal).toCommand(ReportingCommand3);
+        signalCommandMap.map(SupportSignal2).toCommand(ReportingCommand2);
+
+        let signal1: SupportSignal = injector.get(SupportSignal);
+
+        signal1.dispatch();
+
+        assert.deepEqual(reportedExecutions, [
+            ReportingCommand,
+            ReportingCommand2,
+            ReportingCommand3
+        ]);
+    });
+
+    it("test_commands_are_executed_in_order", () => {
+        injector
+            .bind("Function")
+            .toFunction(reportingFunction)
+            .whenTargetNamed("executeCallback");
+
+        signalCommandMap.map(SupportSignal).toCommand(ReportingCommand);
+        signalCommandMap.map(SupportSignal).toCommand(ReportingCommand2);
+        signalCommandMap.map(SupportSignal).toCommand(ReportingCommand3);
+
+        let signal: SupportSignal = injector.get(SupportSignal);
+
+        signal.dispatch();
+
+        assert.deepEqual(reportedExecutions, [
+            ReportingCommand,
+            ReportingCommand2,
+            ReportingCommand3
+        ]);
+    });
+
+    it("test_hooks_are_called", () => {
+        assert.equal(hookCallCount(ReportingHook, ReportingHook), 2);
+    });
+
+    it("test_command_is_injected_into_hook", () => {
+        let executedCommand: ReportingCommand = null;
+        let injectedCommand: ReportingCommand = null;
+
+        injector
+            .bind("Function")
+            .toFunction((command: ReportingCommand, commandClass: any) => {
+                executedCommand = command;
+            })
+            .whenTargetNamed("executeCallback");
+
+        injector
+            .bind("Function")
+            .toFunction((hook: ReportingHook, hookClass: any) => {
+                injectedCommand = hook.command;
+            })
+            .whenTargetNamed("hookCallback");
+
+        signalCommandMap
+            .map(SupportSignal)
+            .toCommand(ReportingCommand)
+            .withHooks(ReportingHook);
+
+        let signal: SupportSignal = injector.get(SupportSignal);
+
+        signal.dispatch();
+
+        assert.isNotNull(injectedCommand);
+        assert.isNotNull(executedCommand);
+        assert.equal(injectedCommand, executedCommand);
+    });
+
+    it("test_command_executes_when_the_guard_allows", () => {
+        assert.equal(commandExecutionCountWithGuards(HappyGuard), 1);
+    });
+
+    it("test_command_executes_when_all_guards_allow", () => {
+        assert.equal(
+            commandExecutionCountWithGuards(HappyGuard, HappyGuard),
+            1
+        );
+    });
+
+    it("test_command_does_not_execute_when_the_guard_denies", () => {
+        assert.equal(commandExecutionCountWithGuards(GrumpyGuard), 0);
+    });
+
+    it("test_command_does_not_execute_when_any_guards_denies", () => {
+        assert.equal(
+            commandExecutionCountWithGuards(HappyGuard, GrumpyGuard),
+            0
+        );
+    });
+
+    it("test_command_does_not_execute_when_all_guards_deny", () => {
+        assert.equal(
+            commandExecutionCountWithGuards(GrumpyGuard, GrumpyGuard),
+            0
+        );
+    });
+
+    it("test_payload_is_injected_into_guard", () => {
+        let injected: any = null;
+
+        injector
+            .bind("Function")
+            .toFunction((guard: PayloadInjectedGuard, guardClass: any) => {
+                injected = guard.payload;
+            })
+            .whenTargetNamed("approveCallback");
+
+        signalCommandMap
+            .map(StrictPayloadCarryingSignal)
+            .toCommand(NullCommand)
+            .withGuards(PayloadInjectedGuard);
+
+        let payload: Payload = new Payload();
+        let signal: StrictPayloadCarryingSignal = injector.get(
+            StrictPayloadCarryingSignal
+        );
+
+        signal.dispatch(payload);
+
+        assert.isNotNull(injected);
+        assert.equal(injected, payload);
+    });
+
+    it("test_payload_is_injected_into_hook", () => {
+        let injected: any = null;
+
+        injector
+            .bind("Function")
+            .toFunction((hook: PayloadInjectedHook, hookClass: any) => {
+                injected = hook.payload;
+            })
+            .whenTargetNamed("hookCallback");
+
+        signalCommandMap
+            .map(StrictPayloadCarryingSignal)
+            .toCommand(NullCommand)
+            .withHooks(PayloadInjectedHook);
+
+        let payload: Payload = new Payload();
+        let signal: StrictPayloadCarryingSignal = injector.get(
+            StrictPayloadCarryingSignal
+        );
+
+        signal.dispatch(payload);
+
+        assert.isNotNull(injected);
+        assert.equal(injected, payload);
+    });
+
+    it("test_strict_payload_is_passed_to_execute_method", () => {
+        let injected: any = null;
+
+        injector
+            .bind("Function")
+            .toFunction((command: ExecuteMethodWithParametersCommand) => {
+                injected = command.payload;
+            })
+            .whenTargetNamed("executeCallback");
+
+        signalCommandMap
+            .map(StrictPayloadCarryingSignal)
+            .toCommand(ExecuteMethodWithParametersCommand);
+
+        let payload: Payload = new Payload();
+        let signal: StrictPayloadCarryingSignal = injector.get(
+            StrictPayloadCarryingSignal
+        );
+
+        signal.dispatch(payload);
+
+        assert.isNotNull(injected);
+        assert.equal(injected, payload);
+    });
+
+    it("test_loose_payload_isnt_passed_to_execute_method", () => {
+        let injected: any = null;
+
+        injector
+            .bind("Function")
+            .toFunction((command: ExecuteMethodWithParametersCommand) => {
+                injected = command.payload;
+            })
+            .whenTargetNamed("executeCallback");
+
+        signalCommandMap
+            .map(SupportSignal)
+            .toCommand(ExecuteMethodWithParametersCommand);
+
+        let payload: Payload = new Payload();
+        let signal: SupportSignal = injector.get(SupportSignal);
+
+        signal.dispatch(payload);
+
+        assert.isNull(injected);
+    });
+
+    it("test_cascading_signals_do_not_throw_unmap_errors", () => {
+        let executeCount: number = 0;
+
+        injector
+            .bind("Function")
+            .toFunction(() => {
+                executeCount++;
+            })
+            .whenTargetNamed("executeCallback");
+
+        injector.bind(ISignalCommandMap).toConstantValue(signalCommandMap);
+
+        signalCommandMap
+            .map(SupportSignal)
+            .toCommand(CascadingCommand)
+            .once();
+        let signal: SupportSignal = injector.get(SupportSignal);
+
+        signal.dispatch();
+
+        assert.equal(executeCount, 1);
+    });
+
+    it("test_execution_sequence_is_guard_command_guard_command_for_multiple_mappings_to_same_signal", () => {
+        injector
+            .bind("Function")
+            .toFunction(reportingFunction)
+            .whenTargetNamed("executeCallback");
+
+        injector
+            .bind("Function")
+            .toFunction(reportingFunction)
+            .whenTargetNamed("approveCallback");
+
+        signalCommandMap
+            .map(SupportSignal)
+            .toCommand(ReportingCommand)
+            .withGuards(ReportingGuard);
+        signalCommandMap
+            .map(SupportSignal)
+            .toCommand(ReportingCommand2)
+            .withGuards(ReportingGuard2);
+
+        let signal: SupportSignal = injector.get(SupportSignal);
+
+        signal.dispatch();
+
+        assert.deepEqual(reportedExecutions, [
+            ReportingGuard,
+            ReportingCommand,
+            ReportingGuard2,
+            ReportingCommand2
+        ]);
+    });
+
+    it("test_previously_constructed_command_does_not_slip_through_the_loop", () => {
+        injector
+            .bind("Function")
+            .toFunction(reportingFunction)
+            .whenTargetNamed("executeCallback");
+
+        signalCommandMap
+            .map(SupportSignal)
+            .toCommand(ReportingCommand)
+            .withGuards(HappyGuard);
+        signalCommandMap
+            .map(SupportSignal)
+            .toCommand(ReportingCommand2)
+            .withGuards(GrumpyGuard);
+
+        let signal: SupportSignal = injector.get(SupportSignal);
+
+        signal.dispatch();
+
+        assert.deepEqual(reportedExecutions, [ReportingCommand]);
+    });
+
+    it("test_command_executes_when_signal_mapped_to_injector_up_front", () => {
+        injector
+            .bind("Function")
+            .toFunction(reportingFunction)
+            .whenTargetNamed("executeCallback");
+
+        injector
+            .bind(SupportSignal)
+            .toSelf()
+            .inSingletonScope();
+
+        signalCommandMap.map(SupportSignal).toCommand(ReportingCommand);
+
+        let signal: SupportSignal = injector.get(SupportSignal);
+
+        signal.dispatch();
+
+        assert.deepEqual(reportedExecutions, [ReportingCommand]);
+    });
+});

--- a/test/robotlegs/bender/extensions/signalCommandMap/impl/signalCommandTrigger.test.ts
+++ b/test/robotlegs/bender/extensions/signalCommandMap/impl/signalCommandTrigger.test.ts
@@ -145,8 +145,8 @@ describe("SignalCommandTrigger", () => {
         assert.isFalse(triggered);
     });
 
-    it("command_is_triggered_and_receives_parameters_from_signal_without_value_classes", () => {
-        let expected: any[] = [
+    it("command_is_triggered_but_do_not_receives_parameters_from_signal_without_value_classes", () => {
+        const parameters: any[] = [
             true,
             999,
             "I'm a string!",
@@ -155,6 +155,7 @@ describe("SignalCommandTrigger", () => {
             new Date(),
             [1, 2, 3, 4, 5, 6, 7, 8, 9]
         ];
+        const expected: any[] = [];
         let actual: any[] = [];
 
         let mapper: CommandMapper;
@@ -175,7 +176,7 @@ describe("SignalCommandTrigger", () => {
     });
 
     it("command_is_triggered_and_receives_parameters_from_signal_with_value_classes", () => {
-        let expected: any[] = [
+        const expected: any[] = [
             true,
             999,
             "I'm a string!",

--- a/test/robotlegs/bender/extensions/signalCommandMap/impl/signalCommandTrigger.test.ts
+++ b/test/robotlegs/bender/extensions/signalCommandMap/impl/signalCommandTrigger.test.ts
@@ -1,0 +1,248 @@
+// ------------------------------------------------------------------------------
+//  Copyright (c) 2017 RobotlegsJS. All Rights Reserved.
+//
+//  NOTICE: You are permitted to use, modify, and distribute this file
+//  in accordance with the terms of the license agreement accompanying it.
+// ------------------------------------------------------------------------------
+
+import "../../../../../entry.ts";
+
+import sinon = require("sinon");
+
+import { assert } from "chai";
+
+import {
+    ISignal,
+    MonoSignal,
+    OnceSignal,
+    Signal,
+    DeluxeSignal,
+    PrioritySignal
+} from "@robotlegsjs/signals";
+
+import {
+    injectable,
+    IInjector,
+    RobotlegsInjector,
+    CommandMapper
+} from "@robotlegsjs/core";
+
+import { SignalCommandTrigger } from "../../../../../../src/robotlegs/bender/extensions/signalCommandMap/impl/SignalCommandTrigger";
+
+import { CallbackCommand } from "../support/CallbackCommand";
+import { CallbackParametersCommand } from "../support/CallbackParametersCommand";
+import { NullCommand } from "../support/NullCommand";
+import { ParametersSignal } from "../support/ParametersSignal";
+
+describe("SignalCommandTrigger", () => {
+    let signal: ISignal;
+    let injector: IInjector;
+    let subject: SignalCommandTrigger;
+
+    beforeEach(() => {
+        signal = new Signal();
+        injector = new RobotlegsInjector();
+        subject = new SignalCommandTrigger(injector, ISignal);
+    });
+
+    afterEach(() => {
+        signal.removeAll();
+        signal = null;
+        injector = null;
+        subject = null;
+    });
+
+    it("createMapper_returns_a_command_mapper", () => {
+        let mapper: any = subject.createMapper();
+
+        assert.instanceOf(mapper, CommandMapper);
+    });
+
+    it("test_activate_adds_a_listener", () => {
+        let signalMock = sinon.mock(signal);
+
+        signalMock.expects("add").once();
+
+        injector.bind(ISignal).toConstantValue(signal);
+        subject.activate();
+
+        signalMock.restore();
+        signalMock.verify();
+    });
+
+    it("test_activate_maps_signal_if_was_not_mapped_before", () => {
+        subject = new SignalCommandTrigger(injector, Signal);
+        subject.activate();
+    });
+
+    it("test_deactivate_removes_listener", () => {
+        let signalMock = sinon.mock(signal);
+
+        signalMock.expects("add").once();
+        signalMock.expects("remove").once();
+
+        injector.bind(ISignal).toConstantValue(signal);
+        subject.activate();
+        subject.deactivate();
+
+        signalMock.restore();
+        signalMock.verify();
+    });
+
+    it("test_doesnt_throw_error_when_deactivating_without_signal", () => {
+        let signalMock = sinon.mock(signal);
+
+        signalMock.expects("add").never();
+        signalMock.expects("remove").never();
+
+        injector.bind(ISignal).toConstantValue(signal);
+        subject.deactivate();
+
+        signalMock.restore();
+        signalMock.verify();
+    });
+
+    it("toString_returns_a_string", () => {
+        assert.isString(subject.toString());
+    });
+
+    it("command_is_triggered_when_signal_dispatch_without_parameters", () => {
+        let triggered: boolean = false;
+        let mapper: CommandMapper;
+
+        injector
+            .bind("Function")
+            .toFunction(() => {
+                triggered = true;
+            })
+            .whenTargetNamed("executeCallback");
+
+        injector.bind(ISignal).toConstantValue(signal);
+        mapper = subject.createMapper();
+        mapper.toCommand(CallbackCommand);
+        signal.dispatch();
+
+        assert.isTrue(triggered);
+    });
+
+    it("command_is_not_triggered_when_trigger_is_deactivated", () => {
+        let triggered: boolean = false;
+        let mapper: CommandMapper;
+
+        injector
+            .bind("Function")
+            .toFunction(() => {
+                triggered = true;
+            })
+            .whenTargetNamed("executeCallback");
+
+        injector.bind(ISignal).toConstantValue(signal);
+        mapper = subject.createMapper();
+        mapper.toCommand(CallbackCommand);
+        subject.deactivate();
+        signal.dispatch();
+
+        assert.isFalse(triggered);
+    });
+
+    it("command_is_triggered_and_receives_parameters_from_signal_without_value_classes", () => {
+        let expected: any[] = [
+            true,
+            999,
+            "I'm a string!",
+            ISignal,
+            { x: 5, y: 5 },
+            new Date(),
+            [1, 2, 3, 4, 5, 6, 7, 8, 9]
+        ];
+        let actual: any[] = [];
+
+        let mapper: CommandMapper;
+
+        injector
+            .bind("Function")
+            .toFunction((parameter: any) => {
+                actual.push(parameter);
+            })
+            .whenTargetNamed("reportParameter");
+
+        injector.bind(ISignal).toConstantValue(signal);
+        mapper = subject.createMapper();
+        mapper.toCommand(CallbackParametersCommand);
+        signal.dispatch.apply(signal, expected);
+
+        assert.deepEqual(actual, expected);
+    });
+
+    it("command_is_triggered_and_receives_parameters_from_signal_with_value_classes", () => {
+        let expected: any[] = [
+            true,
+            999,
+            "I'm a string!",
+            ISignal,
+            { x: 5, y: 5 },
+            new Date(),
+            [1, 2, 3, 4, 5, 6, 7, 8, 9]
+        ];
+        let actual: any[] = [];
+
+        let mapper: CommandMapper;
+
+        injector
+            .bind("Function")
+            .toFunction((parameter: any) => {
+                actual.push(parameter);
+            })
+            .whenTargetNamed("reportParameter");
+
+        signal = new ParametersSignal();
+        injector.bind(ISignal).toConstantValue(signal);
+        mapper = subject.createMapper();
+        mapper.toCommand(CallbackParametersCommand);
+        signal.dispatch.apply(signal, expected);
+
+        assert.deepEqual(actual, expected);
+    });
+
+    it("mapping_processor_is_called", () => {
+        let processors: Function[] = [];
+        let callCount: number = 0;
+        let mapper: CommandMapper;
+
+        processors.push((mapping: any) => {
+            callCount++;
+        });
+
+        injector.bind(ISignal).toConstantValue(signal);
+        subject = new SignalCommandTrigger(injector, ISignal, processors);
+        mapper = subject.createMapper();
+        mapper.toCommand(NullCommand);
+        signal.dispatch();
+
+        assert.equal(callCount, 1);
+    });
+
+    it("mapping_processors_are_called", () => {
+        let processors: Function[] = [];
+        let callCount: number = 0;
+        let mapper: CommandMapper;
+
+        processors.push((mapping: any) => {
+            callCount++;
+        });
+        processors.push((mapping: any) => {
+            callCount++;
+        });
+        processors.push((mapping: any) => {
+            callCount++;
+        });
+
+        injector.bind(ISignal).toConstantValue(signal);
+        subject = new SignalCommandTrigger(injector, ISignal, processors);
+        mapper = subject.createMapper();
+        mapper.toCommand(NullCommand);
+        signal.dispatch();
+
+        assert.equal(callCount, 3);
+    });
+});

--- a/test/robotlegs/bender/extensions/signalCommandMap/impl/signalCommandTrigger.test.ts
+++ b/test/robotlegs/bender/extensions/signalCommandMap/impl/signalCommandTrigger.test.ts
@@ -42,7 +42,7 @@ describe("SignalCommandTrigger", () => {
     beforeEach(() => {
         signal = new Signal();
         injector = new RobotlegsInjector();
-        subject = new SignalCommandTrigger(injector, ISignal);
+        subject = new SignalCommandTrigger(injector, Signal);
     });
 
     afterEach(() => {
@@ -215,7 +215,7 @@ describe("SignalCommandTrigger", () => {
         });
 
         injector.bind(ISignal).toConstantValue(signal);
-        subject = new SignalCommandTrigger(injector, ISignal, processors);
+        subject = new SignalCommandTrigger(injector, Signal, processors);
         mapper = subject.createMapper();
         mapper.toCommand(NullCommand);
         signal.dispatch();
@@ -239,7 +239,7 @@ describe("SignalCommandTrigger", () => {
         });
 
         injector.bind(ISignal).toConstantValue(signal);
-        subject = new SignalCommandTrigger(injector, ISignal, processors);
+        subject = new SignalCommandTrigger(injector, Signal, processors);
         mapper = subject.createMapper();
         mapper.toCommand(NullCommand);
         signal.dispatch();

--- a/test/robotlegs/bender/extensions/signalCommandMap/impl/signalCommandTrigger.test.ts
+++ b/test/robotlegs/bender/extensions/signalCommandMap/impl/signalCommandTrigger.test.ts
@@ -35,7 +35,7 @@ import { NullCommand } from "../support/NullCommand";
 import { ParametersSignal } from "../support/ParametersSignal";
 
 describe("SignalCommandTrigger", () => {
-    let signal: ISignal;
+    let signal: Signal;
     let injector: IInjector;
     let subject: SignalCommandTrigger;
 
@@ -63,7 +63,7 @@ describe("SignalCommandTrigger", () => {
 
         signalMock.expects("add").once();
 
-        injector.bind(ISignal).toConstantValue(signal);
+        injector.bind(Signal).toConstantValue(signal);
         subject.activate();
 
         signalMock.restore();
@@ -81,7 +81,7 @@ describe("SignalCommandTrigger", () => {
         signalMock.expects("add").once();
         signalMock.expects("remove").once();
 
-        injector.bind(ISignal).toConstantValue(signal);
+        injector.bind(Signal).toConstantValue(signal);
         subject.activate();
         subject.deactivate();
 
@@ -95,7 +95,7 @@ describe("SignalCommandTrigger", () => {
         signalMock.expects("add").never();
         signalMock.expects("remove").never();
 
-        injector.bind(ISignal).toConstantValue(signal);
+        injector.bind(Signal).toConstantValue(signal);
         subject.deactivate();
 
         signalMock.restore();
@@ -117,7 +117,7 @@ describe("SignalCommandTrigger", () => {
             })
             .whenTargetNamed("executeCallback");
 
-        injector.bind(ISignal).toConstantValue(signal);
+        injector.bind(Signal).toConstantValue(signal);
         mapper = subject.createMapper();
         mapper.toCommand(CallbackCommand);
         signal.dispatch();
@@ -136,7 +136,7 @@ describe("SignalCommandTrigger", () => {
             })
             .whenTargetNamed("executeCallback");
 
-        injector.bind(ISignal).toConstantValue(signal);
+        injector.bind(Signal).toConstantValue(signal);
         mapper = subject.createMapper();
         mapper.toCommand(CallbackCommand);
         subject.deactivate();
@@ -167,7 +167,7 @@ describe("SignalCommandTrigger", () => {
             })
             .whenTargetNamed("reportParameter");
 
-        injector.bind(ISignal).toConstantValue(signal);
+        injector.bind(Signal).toConstantValue(signal);
         mapper = subject.createMapper();
         mapper.toCommand(CallbackParametersCommand);
         signal.dispatch.apply(signal, expected);
@@ -197,7 +197,7 @@ describe("SignalCommandTrigger", () => {
             .whenTargetNamed("reportParameter");
 
         signal = new ParametersSignal();
-        injector.bind(ISignal).toConstantValue(signal);
+        injector.bind(Signal).toConstantValue(signal);
         mapper = subject.createMapper();
         mapper.toCommand(CallbackParametersCommand);
         signal.dispatch.apply(signal, expected);
@@ -214,7 +214,7 @@ describe("SignalCommandTrigger", () => {
             callCount++;
         });
 
-        injector.bind(ISignal).toConstantValue(signal);
+        injector.bind(Signal).toConstantValue(signal);
         subject = new SignalCommandTrigger(injector, Signal, processors);
         mapper = subject.createMapper();
         mapper.toCommand(NullCommand);
@@ -238,7 +238,7 @@ describe("SignalCommandTrigger", () => {
             callCount++;
         });
 
-        injector.bind(ISignal).toConstantValue(signal);
+        injector.bind(Signal).toConstantValue(signal);
         subject = new SignalCommandTrigger(injector, Signal, processors);
         mapper = subject.createMapper();
         mapper.toCommand(NullCommand);

--- a/test/robotlegs/bender/extensions/signalCommandMap/signalCommandMapExtension.test.ts
+++ b/test/robotlegs/bender/extensions/signalCommandMap/signalCommandMapExtension.test.ts
@@ -57,4 +57,9 @@ describe("SignalCommandMapExtension", () => {
         context.injector.get<RelaySignal>(RelaySignal).dispatch(new Data(3));
         assert.equal(TargetCommand.TARGET_VALUE, 3);
     });
+
+    it("toString_returns_a_string", () => {
+        let extension: SignalCommandMapExtension = new SignalCommandMapExtension();
+        assert.isString(extension.toString());
+    });
 });

--- a/test/robotlegs/bender/extensions/signalCommandMap/support/CallbackCommand.ts
+++ b/test/robotlegs/bender/extensions/signalCommandMap/support/CallbackCommand.ts
@@ -1,0 +1,21 @@
+// ------------------------------------------------------------------------------
+//  Copyright (c) 2017 RobotlegsJS. All Rights Reserved.
+//
+//  NOTICE: You are permitted to use, modify, and distribute this file
+//  in accordance with the terms of the license agreement accompanying it.
+// ------------------------------------------------------------------------------
+
+import { injectable, inject, named } from "inversify";
+
+import { ICommand } from "@robotlegsjs/core";
+
+@injectable()
+export class CallbackCommand implements ICommand {
+    @inject("Function")
+    @named("executeCallback")
+    public callback: Function;
+
+    public execute(): void {
+        this.callback();
+    }
+}

--- a/test/robotlegs/bender/extensions/signalCommandMap/support/CallbackParametersCommand.ts
+++ b/test/robotlegs/bender/extensions/signalCommandMap/support/CallbackParametersCommand.ts
@@ -5,37 +5,71 @@
 //  in accordance with the terms of the license agreement accompanying it.
 // ------------------------------------------------------------------------------
 
-import { injectable, inject, named } from "inversify";
+import { injectable, inject, named, optional } from "inversify";
 
 import { ICommand } from "@robotlegsjs/core";
 
 @injectable()
 export class CallbackParametersCommand implements ICommand {
-    @inject(Boolean) public booleanValue: boolean;
+    @inject(Boolean)
+    @optional()
+    public booleanValue: boolean;
 
-    @inject(Number) public numValue: number;
+    @inject(Number)
+    @optional()
+    public numValue: number;
 
-    @inject(String) public stringValue: string;
+    @inject(String)
+    @optional()
+    public stringValue: string;
 
-    @inject(Symbol) public symbolValue: symbol;
+    @inject(Symbol)
+    @optional()
+    public symbolValue: symbol;
 
-    @inject(Object) public objectValue: object;
+    @inject(Object)
+    @optional()
+    public objectValue: object;
 
-    @inject(Date) public dateValue: Date;
+    @inject(Date)
+    @optional()
+    public dateValue: Date;
 
-    @inject(Array) public arrayValue: any[];
+    @inject(Array)
+    @optional()
+    public arrayValue: any[];
 
     @inject("Function")
     @named("reportParameter")
     public reportParameter: Function;
 
     public execute(): void {
-        this.reportParameter(this.booleanValue);
-        this.reportParameter(this.numValue);
-        this.reportParameter(this.stringValue);
-        this.reportParameter(this.symbolValue);
-        this.reportParameter(this.objectValue);
-        this.reportParameter(this.dateValue);
-        this.reportParameter(this.arrayValue);
+        if (this.booleanValue) {
+            this.reportParameter(this.booleanValue);
+        }
+
+        if (this.numValue) {
+            this.reportParameter(this.numValue);
+        }
+
+        if (this.stringValue) {
+            this.reportParameter(this.stringValue);
+        }
+
+        if (this.symbolValue) {
+            this.reportParameter(this.symbolValue);
+        }
+
+        if (this.objectValue) {
+            this.reportParameter(this.objectValue);
+        }
+
+        if (this.dateValue) {
+            this.reportParameter(this.dateValue);
+        }
+
+        if (this.arrayValue) {
+            this.reportParameter(this.arrayValue);
+        }
     }
 }

--- a/test/robotlegs/bender/extensions/signalCommandMap/support/CallbackParametersCommand.ts
+++ b/test/robotlegs/bender/extensions/signalCommandMap/support/CallbackParametersCommand.ts
@@ -1,0 +1,41 @@
+// ------------------------------------------------------------------------------
+//  Copyright (c) 2017 RobotlegsJS. All Rights Reserved.
+//
+//  NOTICE: You are permitted to use, modify, and distribute this file
+//  in accordance with the terms of the license agreement accompanying it.
+// ------------------------------------------------------------------------------
+
+import { injectable, inject, named } from "inversify";
+
+import { ICommand } from "@robotlegsjs/core";
+
+@injectable()
+export class CallbackParametersCommand implements ICommand {
+    @inject(Boolean) public booleanValue: boolean;
+
+    @inject(Number) public numValue: number;
+
+    @inject(String) public stringValue: string;
+
+    @inject(Symbol) public symbolValue: symbol;
+
+    @inject(Object) public objectValue: object;
+
+    @inject(Date) public dateValue: Date;
+
+    @inject(Array) public arrayValue: any[];
+
+    @inject("Function")
+    @named("reportParameter")
+    public reportParameter: Function;
+
+    public execute(): void {
+        this.reportParameter(this.booleanValue);
+        this.reportParameter(this.numValue);
+        this.reportParameter(this.stringValue);
+        this.reportParameter(this.symbolValue);
+        this.reportParameter(this.objectValue);
+        this.reportParameter(this.dateValue);
+        this.reportParameter(this.arrayValue);
+    }
+}

--- a/test/robotlegs/bender/extensions/signalCommandMap/support/CascadingCommand.ts
+++ b/test/robotlegs/bender/extensions/signalCommandMap/support/CascadingCommand.ts
@@ -1,0 +1,38 @@
+// ------------------------------------------------------------------------------
+//  Copyright (c) 2017 RobotlegsJS. All Rights Reserved.
+//
+//  NOTICE: You are permitted to use, modify, and distribute this file
+//  in accordance with the terms of the license agreement accompanying it.
+// ------------------------------------------------------------------------------
+
+import { injectable, inject, named } from "inversify";
+
+import { IInjector, ICommand } from "@robotlegsjs/core";
+
+import { ISignalCommandMap } from "../../../../../../src/robotlegs/bender/extensions/signalCommandMap/api/ISignalCommandMap";
+
+import { NullCommand } from "./NullCommand";
+import { SupportSignal } from "./SupportSignal";
+
+@injectable()
+export class CascadingCommand implements ICommand {
+    @inject("Function")
+    @named("executeCallback")
+    public callback: Function;
+
+    @inject(IInjector) public injector: IInjector;
+
+    @inject(ISignalCommandMap) public signalCommandMap: ISignalCommandMap;
+
+    public execute(): void {
+        this.callback();
+
+        this.signalCommandMap
+            .map(SupportSignal)
+            .toCommand(NullCommand)
+            .once();
+
+        let signal: SupportSignal = this.injector.get(SupportSignal);
+        signal.dispatch();
+    }
+}

--- a/test/robotlegs/bender/extensions/signalCommandMap/support/ExecuteMethodWithParametersCommand.ts
+++ b/test/robotlegs/bender/extensions/signalCommandMap/support/ExecuteMethodWithParametersCommand.ts
@@ -1,0 +1,26 @@
+// ------------------------------------------------------------------------------
+//  Copyright (c) 2017 RobotlegsJS. All Rights Reserved.
+//
+//  NOTICE: You are permitted to use, modify, and distribute this file
+//  in accordance with the terms of the license agreement accompanying it.
+// ------------------------------------------------------------------------------
+
+import { injectable, inject, named } from "inversify";
+
+import { ICommand } from "@robotlegsjs/core";
+
+import { Payload } from "./Payload";
+
+@injectable()
+export class ExecuteMethodWithParametersCommand implements ICommand {
+    @inject("Function")
+    @named("executeCallback")
+    public callback: Function;
+
+    public payload: Payload;
+
+    public execute(payload: Payload = null): void {
+        this.payload = payload;
+        this.callback(this);
+    }
+}

--- a/test/robotlegs/bender/extensions/signalCommandMap/support/GrumpyGuard.ts
+++ b/test/robotlegs/bender/extensions/signalCommandMap/support/GrumpyGuard.ts
@@ -1,0 +1,15 @@
+// ------------------------------------------------------------------------------
+//  Copyright (c) 2017 RobotlegsJS. All Rights Reserved.
+//
+//  NOTICE: You are permitted to use, modify, and distribute this file
+//  in accordance with the terms of the license agreement accompanying it.
+// ------------------------------------------------------------------------------
+
+import { injectable, IGuard } from "@robotlegsjs/core";
+
+@injectable()
+export class GrumpyGuard implements IGuard {
+    public approve(): boolean {
+        return false;
+    }
+}

--- a/test/robotlegs/bender/extensions/signalCommandMap/support/HappyGuard.ts
+++ b/test/robotlegs/bender/extensions/signalCommandMap/support/HappyGuard.ts
@@ -1,0 +1,15 @@
+// ------------------------------------------------------------------------------
+//  Copyright (c) 2017 RobotlegsJS. All Rights Reserved.
+//
+//  NOTICE: You are permitted to use, modify, and distribute this file
+//  in accordance with the terms of the license agreement accompanying it.
+// ------------------------------------------------------------------------------
+
+import { injectable, IGuard } from "@robotlegsjs/core";
+
+@injectable()
+export class HappyGuard implements IGuard {
+    public approve(): boolean {
+        return true;
+    }
+}

--- a/test/robotlegs/bender/extensions/signalCommandMap/support/NullCommand.ts
+++ b/test/robotlegs/bender/extensions/signalCommandMap/support/NullCommand.ts
@@ -1,0 +1,17 @@
+// ------------------------------------------------------------------------------
+//  Copyright (c) 2017 RobotlegsJS. All Rights Reserved.
+//
+//  NOTICE: You are permitted to use, modify, and distribute this file
+//  in accordance with the terms of the license agreement accompanying it.
+// ------------------------------------------------------------------------------
+
+import { injectable, inject, named } from "inversify";
+
+import { ICommand } from "@robotlegsjs/core";
+
+@injectable()
+export class NullCommand implements ICommand {
+    public execute(): void {
+        // do nothing.
+    }
+}

--- a/test/robotlegs/bender/extensions/signalCommandMap/support/ParametersSignal.ts
+++ b/test/robotlegs/bender/extensions/signalCommandMap/support/ParametersSignal.ts
@@ -1,0 +1,17 @@
+// ------------------------------------------------------------------------------
+//  Copyright (c) 2017 RobotlegsJS. All Rights Reserved.
+//
+//  NOTICE: You are permitted to use, modify, and distribute this file
+//  in accordance with the terms of the license agreement accompanying it.
+// ------------------------------------------------------------------------------
+
+import { injectable } from "inversify";
+
+import { Signal } from "@robotlegsjs/signals";
+
+@injectable()
+export class ParametersSignal extends Signal {
+    constructor() {
+        super(Boolean, Number, String, Symbol, Object, Date, Array);
+    }
+}

--- a/test/robotlegs/bender/extensions/signalCommandMap/support/Payload.ts
+++ b/test/robotlegs/bender/extensions/signalCommandMap/support/Payload.ts
@@ -1,0 +1,11 @@
+// ------------------------------------------------------------------------------
+//  Copyright (c) 2017 RobotlegsJS. All Rights Reserved.
+//
+//  NOTICE: You are permitted to use, modify, and distribute this file
+//  in accordance with the terms of the license agreement accompanying it.
+// ------------------------------------------------------------------------------
+
+import { injectable } from "inversify";
+
+@injectable()
+export class Payload {}

--- a/test/robotlegs/bender/extensions/signalCommandMap/support/PayloadInjectedCallbackCommand.ts
+++ b/test/robotlegs/bender/extensions/signalCommandMap/support/PayloadInjectedCallbackCommand.ts
@@ -1,0 +1,25 @@
+// ------------------------------------------------------------------------------
+//  Copyright (c) 2017 RobotlegsJS. All Rights Reserved.
+//
+//  NOTICE: You are permitted to use, modify, and distribute this file
+//  in accordance with the terms of the license agreement accompanying it.
+// ------------------------------------------------------------------------------
+
+import { injectable, inject, named } from "inversify";
+
+import { ICommand } from "@robotlegsjs/core";
+
+import { Payload } from "./Payload";
+
+@injectable()
+export class PayloadInjectedCallbackCommand implements ICommand {
+    @inject("Function")
+    @named("executeCallback")
+    public callback: Function;
+
+    @inject(Payload) public payload: Payload;
+
+    public execute(): void {
+        this.callback(this);
+    }
+}

--- a/test/robotlegs/bender/extensions/signalCommandMap/support/PayloadInjectedGuard.ts
+++ b/test/robotlegs/bender/extensions/signalCommandMap/support/PayloadInjectedGuard.ts
@@ -1,0 +1,24 @@
+// ------------------------------------------------------------------------------
+//  Copyright (c) 2017 RobotlegsJS. All Rights Reserved.
+//
+//  NOTICE: You are permitted to use, modify, and distribute this file
+//  in accordance with the terms of the license agreement accompanying it.
+// ------------------------------------------------------------------------------
+
+import { injectable, inject, named } from "inversify";
+
+import { Payload } from "./Payload";
+
+@injectable()
+export class PayloadInjectedGuard {
+    @inject("Function")
+    @named("approveCallback")
+    public callback: Function;
+
+    @inject(Payload) public payload: Payload;
+
+    public approve(): boolean {
+        this.callback(this, PayloadInjectedGuard);
+        return true;
+    }
+}

--- a/test/robotlegs/bender/extensions/signalCommandMap/support/PayloadInjectedHook.ts
+++ b/test/robotlegs/bender/extensions/signalCommandMap/support/PayloadInjectedHook.ts
@@ -1,0 +1,23 @@
+// ------------------------------------------------------------------------------
+//  Copyright (c) 2017 RobotlegsJS. All Rights Reserved.
+//
+//  NOTICE: You are permitted to use, modify, and distribute this file
+//  in accordance with the terms of the license agreement accompanying it.
+// ------------------------------------------------------------------------------
+
+import { injectable, inject, named } from "inversify";
+
+import { Payload } from "./Payload";
+
+@injectable()
+export class PayloadInjectedHook {
+    @inject("Function")
+    @named("hookCallback")
+    public callback: Function;
+
+    @inject(Payload) public payload: Payload;
+
+    public hook(): void {
+        this.callback(this, PayloadInjectedHook);
+    }
+}

--- a/test/robotlegs/bender/extensions/signalCommandMap/support/ReportingCommand.ts
+++ b/test/robotlegs/bender/extensions/signalCommandMap/support/ReportingCommand.ts
@@ -1,0 +1,21 @@
+// ------------------------------------------------------------------------------
+//  Copyright (c) 2017 RobotlegsJS. All Rights Reserved.
+//
+//  NOTICE: You are permitted to use, modify, and distribute this file
+//  in accordance with the terms of the license agreement accompanying it.
+// ------------------------------------------------------------------------------
+
+import { injectable, inject, named } from "inversify";
+
+import { ICommand } from "@robotlegsjs/core";
+
+@injectable()
+export class ReportingCommand implements ICommand {
+    @inject("Function")
+    @named("executeCallback")
+    public callback: Function;
+
+    public execute(): void {
+        this.callback(this, ReportingCommand);
+    }
+}

--- a/test/robotlegs/bender/extensions/signalCommandMap/support/ReportingCommand2.ts
+++ b/test/robotlegs/bender/extensions/signalCommandMap/support/ReportingCommand2.ts
@@ -1,0 +1,21 @@
+// ------------------------------------------------------------------------------
+//  Copyright (c) 2017 RobotlegsJS. All Rights Reserved.
+//
+//  NOTICE: You are permitted to use, modify, and distribute this file
+//  in accordance with the terms of the license agreement accompanying it.
+// ------------------------------------------------------------------------------
+
+import { injectable, inject, named } from "inversify";
+
+import { ICommand } from "@robotlegsjs/core";
+
+@injectable()
+export class ReportingCommand2 implements ICommand {
+    @inject("Function")
+    @named("executeCallback")
+    public callback: Function;
+
+    public execute(): void {
+        this.callback(this, ReportingCommand2);
+    }
+}

--- a/test/robotlegs/bender/extensions/signalCommandMap/support/ReportingCommand3.ts
+++ b/test/robotlegs/bender/extensions/signalCommandMap/support/ReportingCommand3.ts
@@ -1,0 +1,21 @@
+// ------------------------------------------------------------------------------
+//  Copyright (c) 2017 RobotlegsJS. All Rights Reserved.
+//
+//  NOTICE: You are permitted to use, modify, and distribute this file
+//  in accordance with the terms of the license agreement accompanying it.
+// ------------------------------------------------------------------------------
+
+import { injectable, inject, named } from "inversify";
+
+import { ICommand } from "@robotlegsjs/core";
+
+@injectable()
+export class ReportingCommand3 implements ICommand {
+    @inject("Function")
+    @named("executeCallback")
+    public callback: Function;
+
+    public execute(): void {
+        this.callback(this, ReportingCommand3);
+    }
+}

--- a/test/robotlegs/bender/extensions/signalCommandMap/support/ReportingGuard.ts
+++ b/test/robotlegs/bender/extensions/signalCommandMap/support/ReportingGuard.ts
@@ -1,0 +1,22 @@
+// ------------------------------------------------------------------------------
+//  Copyright (c) 2017 RobotlegsJS. All Rights Reserved.
+//
+//  NOTICE: You are permitted to use, modify, and distribute this file
+//  in accordance with the terms of the license agreement accompanying it.
+// ------------------------------------------------------------------------------
+
+import { injectable, inject, named } from "inversify";
+
+import { IGuard } from "@robotlegsjs/core";
+
+@injectable()
+export class ReportingGuard implements IGuard {
+    @inject("Function")
+    @named("approveCallback")
+    public callback: Function;
+
+    public approve(): boolean {
+        this.callback(this, ReportingGuard);
+        return true;
+    }
+}

--- a/test/robotlegs/bender/extensions/signalCommandMap/support/ReportingGuard2.ts
+++ b/test/robotlegs/bender/extensions/signalCommandMap/support/ReportingGuard2.ts
@@ -1,0 +1,22 @@
+// ------------------------------------------------------------------------------
+//  Copyright (c) 2017 RobotlegsJS. All Rights Reserved.
+//
+//  NOTICE: You are permitted to use, modify, and distribute this file
+//  in accordance with the terms of the license agreement accompanying it.
+// ------------------------------------------------------------------------------
+
+import { injectable, inject, named } from "inversify";
+
+import { IGuard } from "@robotlegsjs/core";
+
+@injectable()
+export class ReportingGuard2 implements IGuard {
+    @inject("Function")
+    @named("approveCallback")
+    public callback: Function;
+
+    public approve(): boolean {
+        this.callback(this, ReportingGuard2);
+        return true;
+    }
+}

--- a/test/robotlegs/bender/extensions/signalCommandMap/support/ReportingHook.ts
+++ b/test/robotlegs/bender/extensions/signalCommandMap/support/ReportingHook.ts
@@ -1,0 +1,23 @@
+// ------------------------------------------------------------------------------
+//  Copyright (c) 2017 RobotlegsJS. All Rights Reserved.
+//
+//  NOTICE: You are permitted to use, modify, and distribute this file
+//  in accordance with the terms of the license agreement accompanying it.
+// ------------------------------------------------------------------------------
+
+import { injectable, inject, named } from "inversify";
+
+import { ReportingCommand } from "./ReportingCommand";
+
+@injectable()
+export class ReportingHook {
+    @inject("Function")
+    @named("hookCallback")
+    public callback: Function;
+
+    @inject(ReportingCommand) public command: ReportingCommand;
+
+    public hook() {
+        this.callback(this, ReportingHook);
+    }
+}

--- a/test/robotlegs/bender/extensions/signalCommandMap/support/StrictPayloadCarryingSignal.ts
+++ b/test/robotlegs/bender/extensions/signalCommandMap/support/StrictPayloadCarryingSignal.ts
@@ -1,0 +1,19 @@
+// ------------------------------------------------------------------------------
+//  Copyright (c) 2017 RobotlegsJS. All Rights Reserved.
+//
+//  NOTICE: You are permitted to use, modify, and distribute this file
+//  in accordance with the terms of the license agreement accompanying it.
+// ------------------------------------------------------------------------------
+
+import { injectable } from "inversify";
+
+import { Signal } from "@robotlegsjs/signals";
+
+import { Payload } from "./Payload";
+
+@injectable()
+export class StrictPayloadCarryingSignal extends Signal {
+    constructor() {
+        super(Payload);
+    }
+}

--- a/test/robotlegs/bender/extensions/signalCommandMap/support/SupportSignal.ts
+++ b/test/robotlegs/bender/extensions/signalCommandMap/support/SupportSignal.ts
@@ -1,0 +1,17 @@
+// ------------------------------------------------------------------------------
+//  Copyright (c) 2017 RobotlegsJS. All Rights Reserved.
+//
+//  NOTICE: You are permitted to use, modify, and distribute this file
+//  in accordance with the terms of the license agreement accompanying it.
+// ------------------------------------------------------------------------------
+
+import { injectable } from "inversify";
+
+import { Signal } from "@robotlegsjs/signals";
+
+@injectable()
+export class SupportSignal extends Signal {
+    constructor() {
+        super();
+    }
+}

--- a/test/robotlegs/bender/extensions/signalCommandMap/support/SupportSignal2.ts
+++ b/test/robotlegs/bender/extensions/signalCommandMap/support/SupportSignal2.ts
@@ -1,0 +1,17 @@
+// ------------------------------------------------------------------------------
+//  Copyright (c) 2017 RobotlegsJS. All Rights Reserved.
+//
+//  NOTICE: You are permitted to use, modify, and distribute this file
+//  in accordance with the terms of the license agreement accompanying it.
+// ------------------------------------------------------------------------------
+
+import { injectable } from "inversify";
+
+import { Signal } from "@robotlegsjs/signals";
+
+@injectable()
+export class SupportSignal2 extends Signal {
+    constructor() {
+        super();
+    }
+}


### PR DESCRIPTION
- The type of **signalClass** parameter now is `IClass<ISignal>`, that means you can only **map** and **unmap** a concrete reference for a **Signal** class or some class that is extending the **Signal** class.

- The **CommandExecutor** now is able to remove a mapping because the **removeMapping** function is passed using the **bind** method to solve the reference for **this** element.

- All original unit tests from the **AS3** implementation are now migrated and are working as expected, ensuring that this **TypeScript** version is keeping the same behavior. Take a look inside the **test** folder to see different ways of using the **ISignalCommandMap** service.