### PR TITLE
Update @robotlegsjs/core to the latest version 🚀

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@
 
 ### v0.1.1
 
+- Update @robotlegsjs/core to version 0.1.3 (see #41).
+
 - Update @robotlegsjs/signals to version 0.1.1 (see #36).
 
 ### [v0.1.0](https://github.com/RobotlegsJS/RobotlegsJS-SignalCommandMap/releases/tag/0.1.0) - 2017-11-16

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
   },
   "homepage": "https://github.com/RobotlegsJS/RobotlegsJS-SignalCommandMap#readme",
   "dependencies": {
-    "@robotlegsjs/core": "^0.1.1",
+    "@robotlegsjs/core": "^0.1.3",
     "@robotlegsjs/signals": "^0.1.1"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,11 +2,11 @@
 # yarn lockfile v1
 
 
-"@robotlegsjs/core@^0.1.1":
-  version "0.1.1"
-  resolved "https://registry.npmjs.org/@robotlegsjs/core/-/core-0.1.1.tgz#7522c7481d12c562ab41e6b6653235cf76bafaf4"
+"@robotlegsjs/core@^0.1.3":
+  version "0.1.3"
+  resolved "https://registry.npmjs.org/@robotlegsjs/core/-/core-0.1.3.tgz#0899fc6f25ac2b07c652e1a348feba23c7842abe"
   dependencies:
-    inversify "^4.5.1"
+    inversify "^4.11.1"
 
 "@robotlegsjs/signals@^0.1.1":
   version "0.1.1"
@@ -2606,9 +2606,9 @@ invariant@^2.2.2:
   dependencies:
     loose-envify "^1.0.0"
 
-inversify@^4.5.1:
-  version "4.5.1"
-  resolved "https://registry.npmjs.org/inversify/-/inversify-4.5.1.tgz#2f8a249e1fc5346e4f28b4b86dfae5af1b673178"
+inversify@^4.11.1:
+  version "4.11.1"
+  resolved "https://registry.npmjs.org/inversify/-/inversify-4.11.1.tgz#9a10635d1fd347da11da96475b3608babd5945a6"
 
 invert-kv@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
## Version **0.1.3** of [@robotlegsjs/core](https://github.com/RobotlegsJS/RobotlegsJS) was just published.