### PR TITLE
Update @robotlegsjs/core to the latest version 🚀 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,8 @@ Types of changes:
 
 - Update `@robotlegsjs/signals` to version `1.0.3` (see #98).
 
+- Update `@robotlegsjs/core` to version `1.0.3` (see #99).
+
 - Update `instanbul` settings (see #97).
 
 - Migrate project to `travis-ci.com`.

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "lib": "./lib"
   },
   "dependencies": {
-    "@robotlegsjs/core": "^1.0.2",
+    "@robotlegsjs/core": "^1.0.3",
     "@robotlegsjs/signals": "^1.0.3"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -101,10 +101,10 @@
   resolved "https://registry.npmjs.org/@istanbuljs/nyc-config-typescript/-/nyc-config-typescript-0.1.3.tgz#944d15b3ebdb71f963a628daffaa25ade981bb86"
   integrity sha512-EzRFg92bRSD1W/zeuNkeGwph0nkWf+pP2l/lYW4/5hav7RjKKBN5kV1Ix7Tvi0CMu3pC4Wi/U7rNisiJMR3ORg==
 
-"@robotlegsjs/core@^1.0.2":
-  version "1.0.2"
-  resolved "https://registry.npmjs.org/@robotlegsjs/core/-/core-1.0.2.tgz#084aa26bbea00b9659bc11dae3e1925f25210c9f"
-  integrity sha512-tMxAdsKM1hAPQztD/vy9QNG1NnBWKpG0+A6XBi7IigPmJmVoVxBw4xZvODWsDWoCLvhs/a9IOok2edUDxDiNrg==
+"@robotlegsjs/core@^1.0.3":
+  version "1.0.3"
+  resolved "https://registry.npmjs.org/@robotlegsjs/core/-/core-1.0.3.tgz#3ae018b4e8834552a076caf4f4eed7fe1433951a"
+  integrity sha512-fWQWvEqCx9SojQsIMbd1thvylhiUqyX11CBlnUJrpRxZEoLIWZ+F71E/7D662en79HGxtb8OAZZR7WXaiixljw==
   dependencies:
     inversify "^5.0.1"
     tslib "^1.10.0"
@@ -2767,9 +2767,9 @@ handle-thing@^2.0.0:
   integrity sha512-d4sze1JNC454Wdo2fkuyzCr6aHcbL6PGGuFAz0Li/NcOm1tCHGnWDRmJP85dh9IhQErTc2svWFEX5xHIOo//kQ==
 
 handlebars@^4.1.2:
-  version "4.4.3"
-  resolved "https://registry.npmjs.org/handlebars/-/handlebars-4.4.3.tgz#180bae52c1d0e9ec0c15d7e82a4362d662762f6e"
-  integrity sha512-B0W4A2U1ww3q7VVthTKfh+epHx+q4mCt6iK+zEAzbMBpWQAwxCeKxEGpj/1oQTpzPXDNSOG7hmG14TsISH50yw==
+  version "4.4.4"
+  resolved "https://registry.npmjs.org/handlebars/-/handlebars-4.4.4.tgz#d6cbdda5fb0706e6c1b43356afea30016106c60f"
+  integrity sha512-KDVIZvMQSrWTqwmJABFP5jI1rZDERoSDUD36BpccZni1h690o8cAmh3axy9XmVnT5A5i6KqtvE3lzxV/FOeVqA==
   dependencies:
     neo-async "^2.6.0"
     optimist "^0.6.1"


### PR DESCRIPTION
The dependency [@robotlegsjs/core](https://github.com/RobotlegsJS/RobotlegsJS) was updated from `1.0.2` to `1.0.3`.